### PR TITLE
Add Mathematica 11.3.0 中文版 Win版 磁力链接

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,7 +39,10 @@
 
 <p><strong>以下地址均未失效，只是百度盘暂时抽风，在地址栏上重新回车一次（不能直接刷新！）就能看到下载链了！</strong></p>
 
-      <p>Mathematica11.3.0英文版 (Win + Linux + Mac + 破解工具)，磁力链接：</p>
+      <p>Mathematica11.3.0 中文版 (Win版 + 破解工具)，磁力链接：</p>
+      <p>magnet:?xt=urn:btih:29de7b51d85fa418c0af9812fd127a5acad158bd</p>
+      
+      <p>Mathematica11.3.0 英文版 (Win + Linux + Mac + 破解工具)，磁力链接：</p>
       <p>magnet:?xt=urn:btih:aad5462ec9e4c20d350a53caff59bf6b7758a249</p>
       
 <p><a href="https://pan.baidu.com/s/1o7CW4uY">MMA11.2.0中文版 Win版，Mac版</a> 密码: vh23</p>（Linux版无中文版，自行汉化的方法可参考<a href="http://tieba.baidu.com/p/4024190694">这帖</a>）

--- a/index.html
+++ b/index.html
@@ -45,6 +45,8 @@
       <p>Mathematica11.3.0 英文版 (Win + Linux + Mac + 破解工具)，磁力链接：</p>
       <p>magnet:?xt=urn:btih:aad5462ec9e4c20d350a53caff59bf6b7758a249</p>
       
+      <p>注意：以上磁链中的 html 文件也要下载，那是算号器。部分下载工具（如迅雷）在新建任务时默认不下载该类型的文件。</p>
+      
 <p><a href="https://pan.baidu.com/s/1o7CW4uY">MMA11.2.0中文版 Win版，Mac版</a> 密码: vh23</p>（Linux版无中文版，自行汉化的方法可参考<a href="http://tieba.baidu.com/p/4024190694">这帖</a>）
  
 <p><a href="https://pan.baidu.com/s/1jIJzMGe">MMA11.2.0英文版 Win版，Mac版，Linux版</a>  密码：vvuj</p>（注意，英文版也是可以调出中文提示的，但是它没有中文帮助，只有带了中文帮助的才叫中文版！）      


### PR DESCRIPTION
- 这份磁链对应的种子文件文件名为：**Mathematica 11.3 Chinese with Keygen (Windows only)**
- 安装包来自官方下载器，已经过测试，可以成功安装并激活。测试环境为：Windows Server 2016 (1607)
- Mac 版还是老问题，官方下载器下载速度实在太慢，挂 SS 代理都没用。连续挂 2 周估计能下载完，但是 MacBook 是我问同学借的，我自己的 MacBook 已经装了 Windows 和 Arch Linux 了，只能放弃。Mac 版的下载器好像不会走 Shadowsocks 的 SOCKS5 代理，如果有好一点的解决方案，请告诉我，谢谢。