### PR TITLE
New version: 13.2.0 ( Main + EN Doc )

### DIFF
--- a/index.md
+++ b/index.md
@@ -54,13 +54,13 @@ Wolfram Engine 的激活方法可参考官网的介绍 [How do I set up the Wolf
 
 下载链接：
 
-### Wolfram Engine 13.0.1
+### Wolfram Engine 13.2.0
 * (13.2.0) Windows + Linux + Mac
   * [SharePoint-API](https://wdm.itsu.eu.org/cf-route/WolframEngine/13.2.0/)
   * [SharePoint-API 备线](https://wdm-v2.itsu.eu.org/auto/WolframEngine/13.2.0/)
 
-### Wolfram Engine 13.0.1
-* (13.2.0) Windows + Linux + Mac
+### Wolfram Engine 13.1.0
+* (13.1.0) Windows + Linux + Mac
   * [SharePoint-API](https://wdm.itsu.eu.org/cf-route/WolframEngine/13.1.0/)
   * [SharePoint-API 备线](https://wdm-v2.itsu.eu.org/auto/WolframEngine/13.1.0/)
 

--- a/index.md
+++ b/index.md
@@ -220,6 +220,26 @@ Wolfram Engine 的激活方法可参考官网的介绍 [How do I set up the Wolf
 
 另外，参看【Q3】。
 
+### Mathematica 13.2.0
+
+> **注意**
+>
+> 从 13.1 开始，Windows, Mac 和 Linux 的主程序均不再携带离线帮助文档，需要另行安装离线文档扩展包。**通常情况下，仅当 Mathematica 主界面语言与离线文档扩展包的语言一致时，Mathematica 才会调用本地帮助文档。**
+> 更详细的内容参看[贴吧相关讨论](https://tieba.baidu.com/p/7675083708)。
+
+> **注意**
+>
+> 从 12.1 开始，Mathematica 仅支持 64 位操作系统。从 12.2 开始，Mathematica 的 Windows 版仅支持 Win10 1709 及以上版本。其他系统要求也显著提高。更详细的内容参看[官方说明](https://support.wolfram.com/6479)。
+
+* 主程序
+  * (13.2.0) Windows + Mac + Linux
+    * [SharePoint-API](https://wdm.itsu.eu.org/cf-route/Mathematica/13.2.0.0/Main/)
+    * [SharePoint-API 备线](https://wdm-v2.itsu.eu.org/auto/Mathematica/13.2.0.0/Main/)
+* 离线文档扩展包
+  * (13.2.0 英文) Windows + Mac + Linux
+    * [SharePoint-API](https://wdm.itsu.eu.org/cf-route/Mathematica/13.2.0.0/WLDocs/EN/) **文件名里有 `CN` 但确实是英文！**
+    * [SharePoint-API 备线](https://wdm-v2.itsu.eu.org/auto/Mathematica/13.2.0.0/WLDocs/EN/) **文件名里有 `CN` 但确实是英文！**
+
 ### Mathematica 13.1.0
 
 > **注意**
@@ -240,8 +260,8 @@ Wolfram Engine 的激活方法可参考官网的介绍 [How do I set up the Wolf
     * [SharePoint-API](https://wdm.itsu.eu.org/cf-route/Mathematica/13.1.0.0/WLDocs/EN/) **文件名里有 `CN` 但确实是英文！**
     * [SharePoint-API 备线](https://wdm-v2.itsu.eu.org/auto/Mathematica/13.1.0.0/WLDocs/EN/) **文件名里有 `CN` 但确实是英文！**
   * (13.1.0 中文) Windows + Mac + Linux
-    * [SharePoint-API](https://wdm.itsu.eu.org/cf-route/Mathematica/13.1.0.0/WLDocs/CN/) **文件名里有 `CN` 但确实是英文！**
-    * [SharePoint-API 备线](https://wdm-v2.itsu.eu.org/auto/Mathematica/13.1.0.0/WLDocs/CN/) **文件名里有 `CN` 但确实是英文！**
+    * [SharePoint-API](https://wdm.itsu.eu.org/cf-route/Mathematica/13.1.0.0/WLDocs/CN/)
+    * [SharePoint-API 备线](https://wdm-v2.itsu.eu.org/auto/Mathematica/13.1.0.0/WLDocs/CN/)
 
 ### Mathematica 13.0.1
 

--- a/index.md
+++ b/index.md
@@ -55,6 +55,16 @@ Wolfram Engine 的激活方法可参考官网的介绍 [How do I set up the Wolf
 下载链接：
 
 ### Wolfram Engine 13.0.1
+* (13.2.0) Windows + Linux + Mac
+  * [SharePoint-API](https://wdm.itsu.eu.org/cf-route/WolframEngine/13.2.0/)
+  * [SharePoint-API 备线](https://wdm-v2.itsu.eu.org/auto/WolframEngine/13.2.0/)
+
+### Wolfram Engine 13.0.1
+* (13.2.0) Windows + Linux + Mac
+  * [SharePoint-API](https://wdm.itsu.eu.org/cf-route/WolframEngine/13.1.0/)
+  * [SharePoint-API 备线](https://wdm-v2.itsu.eu.org/auto/WolframEngine/13.1.0/)
+
+### Wolfram Engine 13.0.1
 * (13.0.1) Windows + Linux + Mac
   * [SharePoint-API](https://wdm.itsu.eu.org/cf-route/WolframEngine/13.0.1/)
   * [SharePoint-API 备线](https://wdm-v2.itsu.eu.org/auto/WolframEngine/13.0.1/)
@@ -224,7 +234,7 @@ Wolfram Engine 的激活方法可参考官网的介绍 [How do I set up the Wolf
 
 > **注意**
 >
-> 从 13.1 开始，Windows, Mac 和 Linux 的主程序均不再携带离线帮助文档，需要另行安装离线文档扩展包。**通常情况下，仅当 Mathematica 主界面语言与离线文档扩展包的语言一致时，Mathematica 才会调用本地帮助文档。**
+> 从 13.1 开始，Windows, Mac 和 Linux 的主程序默认不再携带离线帮助文档，需要另行安装离线文档扩展包。Linux 同时提供附带帮助文档的安装包（文件名含有 `BNDL` 字样）。**通常情况下，仅当 Mathematica 主界面语言与离线文档扩展包的语言一致时，Mathematica 才会调用本地帮助文档。**
 > 更详细的内容参看[贴吧相关讨论](https://tieba.baidu.com/p/7675083708)。
 
 > **注意**
@@ -244,7 +254,7 @@ Wolfram Engine 的激活方法可参考官网的介绍 [How do I set up the Wolf
 
 > **注意**
 >
-> 从 13.1 开始，Windows, Mac 和 Linux 的主程序均不再携带离线帮助文档，需要另行安装离线文档扩展包。**通常情况下，仅当 Mathematica 主界面语言与离线文档扩展包的语言一致时，Mathematica 才会调用本地帮助文档。**
+> 从 13.1 开始，Windows, Mac 和 Linux 的主程序默认不再携带离线帮助文档，需要另行安装离线文档扩展包。Linux 同时提供附带帮助文档的安装包（文件名含有 `BNDL` 字样）。**通常情况下，仅当 Mathematica 主界面语言与离线文档扩展包的语言一致时，Mathematica 才会调用本地帮助文档。**
 > 更详细的内容参看[贴吧相关讨论](https://tieba.baidu.com/p/7675083708)。
 
 > **注意**


### PR DESCRIPTION
## 摘要
* 添加 MMA 13.2.0 主程序和英文文档

## 已知问题
**问题比较奇怪 合PR前请先阅读本段**

注意到国内下载源返回的信息里有由储存服务商提供的 `hash` 字段，例如 WLDocs_13.2.0_MAC_CN.pkg `db4440ccb8d4a1d827db75242ab35f32` 。但实际下载文件得到的 MD5 与之不符。

官网说 [Wolfram User Portal](https://user.wolfram.com/) 提供了hash，但我没找到文件名带 CN 的这套文件的 hash 在哪。

附本次搬运部分文件的 md5sum
```
8ae8f484a72db8d623fff2b69307014c  WLDocs_13.2.0_MAC_CN.pkg
efc293c5e75bb8d1e5c0d7502cde50cb  WLDocs_13.2.0_WIN_CN.zip
31db62eb7df9c937447fdbb48e933c49  WLDocs_13.2.0_LINUX_CN.sh
```