### PR TITLE
增加 13.2.1 和 13.2.0 的文字说明

### DIFF
--- a/index.md
+++ b/index.md
@@ -212,8 +212,16 @@ Wolfram Engine 的激活方法可参考官网的介绍 [How do I set up the Wolf
   * (13.2.1 英文) Linux
     * [WDM Mirror 主线](https://wdm.itsu.eu.org/Rasis/Mathematica/13.2.1.0/BNDL_English/)
     * [WDM Mirror 备线](https://wdm-v2.itsu.eu.org/Grace/Mathematica/13.2.1.0/BNDL_English/)
+* 离线文档扩展包
+  本版本未发布离线文档扩展包，13.2.0 版本的离线文档扩展包理论上可以用于本版本。
 
 ### Mathematica 13.2.0
+
+> **警告**
+>
+> 版本 13.2.0 中，ParametricPlot3D 等内置符号有 bug，会导致部分情况下绘图不正确。
+>
+> **如无特殊原因，请不要选择此版本！** 请选择修复了大量 bug 的 13.2.1 版本。
 
 > **注意**
 >

--- a/index.md
+++ b/index.md
@@ -213,7 +213,7 @@ Wolfram Engine 的激活方法可参考官网的介绍 [How do I set up the Wolf
     * [WDM Mirror 主线](https://wdm.itsu.eu.org/Rasis/Mathematica/13.2.1.0/BNDL_English/)
     * [WDM Mirror 备线](https://wdm-v2.itsu.eu.org/Grace/Mathematica/13.2.1.0/BNDL_English/)
 * 离线文档扩展包
-  本版本未发布离线文档扩展包，13.2.0 版本的离线文档扩展包理论上可以用于本版本。
+  * 本版本未发布离线文档扩展包，13.2.0 版本的离线文档扩展包理论上可以用于本版本。
 
 ### Mathematica 13.2.0
 


### PR DESCRIPTION
## 摘要
* 增加 13.2.1 和 13.2.0 的文字说明：
  * 13.2.1 采用 13.2.0 离线文档
  * 13.2.0 因 bug 不建议使用

## 参考资料
> 版本 13.2.1 中包括了上百个错误修复、功能增强、性能改进和安全更新。
> 
>  _更新日志 - <https://www.wolfram.com/mathematica/quick-revision-history.html.zh>_