### PR TITLE
try fix ci

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -7,9 +7,8 @@ pull_request_rules:
       - '-title~=(?i)\bWIP\b'
     actions:
       merge:
-        strict: "smart"
         method: squash
-        commit_message: "title+body"
+        commit_message_template: "{{ title }}+{{ body }}"
 
   - name: Add label `DuplicateOrInvalid` when abandoned
     conditions:


### PR DESCRIPTION
## 摘要

fix

extra keys not allowed @ pull_request_rules → item 0 → actions → merge → commit_message
extra keys not allowed @ pull_request_rules → item 0 → actions → merge → strict

## 其他信息

ref https://docs.mergify.com/workflow/actions/merge/#using-commit-message-template
